### PR TITLE
Fix variable value test

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,7 @@ fi
 
 if [ -e "$WERCKER_CREATE_FILE_FILENAME" ]
 then
-    if [[ ! -e "$WERCKER_CREATE_FILE_OVERWRITE" && "$WERCKER_CREATE_FILE_OVERWRITE" = "true" ]]
+    if [[ -n "$WERCKER_CREATE_FILE_OVERWRITE" && "$WERCKER_CREATE_FILE_OVERWRITE" = "true" ]]
     then
         debug "file \"$WERCKER_CREATE_FILE_FILENAME\" already exists and will be overwritten because overwrite option is set to true"
     else


### PR DESCRIPTION
It seems the check here is a bit inaccurate. `-e` checks if a **file** exists, `-n` tests if a variable has a non blank/non null value.